### PR TITLE
Add ShortUrlCreation::withPathPrefix()

### DIFF
--- a/src/ShortUrls/Model/ShortUrlCreation.php
+++ b/src/ShortUrls/Model/ShortUrlCreation.php
@@ -24,6 +24,11 @@ final class ShortUrlCreation implements JsonSerializable
         return $this->cloneWithProp('customSlug', $slug)->cloneWithoutProp('shortCodeLength');
     }
 
+    public function withPathPrefix(string $pathPrefix): self
+    {
+        return $this->cloneWithProp('pathPrefix', $pathPrefix);
+    }
+
     public function withShortCodeLength(int $length): self
     {
         return $this->cloneWithProp('shortCodeLength', $length)->cloneWithoutProp('customSlug');

--- a/test/ShortUrls/Model/ShortUrlCreationTest.php
+++ b/test/ShortUrls/Model/ShortUrlCreationTest.php
@@ -35,25 +35,29 @@ class ShortUrlCreationTest extends TestCase
             fn () => ShortUrlCreation::forLongUrl('https://foo.com')
                 ->withTags('foo', 'bar')
                 ->validSince($date) // @phpstan-ignore-line
-                ->withCustomSlug('some-slug'),
+                ->withCustomSlug('some-slug')
+                ->withPathPrefix('my-prefix-'),
             [
                 'longUrl' => 'https://foo.com',
                 'tags' => ['foo', 'bar'],
                 'customSlug' => 'some-slug',
+                'pathPrefix' => 'my-prefix-',
                 'validSince' => $date->format(DateTimeInterface::ATOM), // @phpstan-ignore-line
             ],
         ];
         yield [
             fn () => ShortUrlCreation::forLongUrl('https://foo.com')
                 ->withCustomSlug('some-slug')
+                ->withPathPrefix('my-prefix-')
                 ->withShortCodeLength(50),
-            ['longUrl' => 'https://foo.com', 'shortCodeLength' => 50],
+            ['longUrl' => 'https://foo.com', 'pathPrefix' => 'my-prefix-', 'shortCodeLength' => 50],
         ];
         yield [
             fn () => ShortUrlCreation::forLongUrl('https://foo.com')
                 ->withShortCodeLength(50)
-                ->withCustomSlug('some-slug'),
-            ['longUrl' => 'https://foo.com', 'customSlug' => 'some-slug'],
+                ->withCustomSlug('some-slug')
+                ->withPathPrefix('my-prefix-'),
+            ['longUrl' => 'https://foo.com', 'customSlug' => 'some-slug', 'pathPrefix' => 'my-prefix-'],
         ];
         yield [
             fn () => ShortUrlCreation::forLongUrl('https://foo.com')


### PR DESCRIPTION
Support for "path prefix" on short url creation has been added to [shlink](https://github.com/shlinkio/shlink) via [#1884](https://github.com/shlinkio/shlink/issues/1884). It would be great to have support for this in the php sdk as well.