### PR TITLE
Shlink 4.3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.2', '8.3', '8.4']
-        shlink-version: ['4.2', '4.1', '4.0', '3.7', '3.6', '3.5.4', '3.4.0', '3.3.2']
+        shlink-version: ['4.3', '4.2', '4.1', '4.0', '3.7', '3.6', '3.5.4', '3.4.0', '3.3.2']
         shlink-api-version: ['3']
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [2.4.0] - 2024-11-25
 ### Added
-* *Nothing*
+* Add support for PHP 8.4
+* Add support for Shlink 4.3
 
 ### Changed
 * Switch to xdebug for code coverage reports, as pcov is not marking functions as covered

--- a/src/RedirectRules/Model/RedirectCondition.php
+++ b/src/RedirectRules/Model/RedirectCondition.php
@@ -41,6 +41,16 @@ final readonly class RedirectCondition implements JsonSerializable
         return new self(RedirectConditionType::IP_ADDRESS, $ipAddressPattern);
     }
 
+    public static function forGeolocationCountryCode(string $countryCode): self
+    {
+        return new self(RedirectConditionType::GEOLOCATION_COUNTRY_CODE, $countryCode);
+    }
+
+    public static function forGeolocationCityName(string $cityName): self
+    {
+        return new self(RedirectConditionType::GEOLOCATION_CITY_NAME, $cityName);
+    }
+
     public static function fromArray(array $payload): self
     {
         $originalType = $payload['type'] ?? '';

--- a/src/RedirectRules/Model/RedirectConditionType.php
+++ b/src/RedirectRules/Model/RedirectConditionType.php
@@ -8,5 +8,7 @@ enum RedirectConditionType: string
     case LANGUAGE = 'language';
     case QUERY_PARAM = 'query-param';
     case IP_ADDRESS = 'ip-address';
+    case GEOLOCATION_COUNTRY_CODE = 'geolocation-country-code';
+    case GEOLOCATION_CITY_NAME = 'geolocation-city-name';
     case UNKNOWN = 'unknown';
 }

--- a/src/ShortUrls/Model/ShortUrl.php
+++ b/src/ShortUrls/Model/ShortUrl.php
@@ -15,6 +15,9 @@ final readonly class ShortUrl
     /** @deprecated Not returned by Shlink 4.0.0 */
     public DeviceLongUrls|null $deviceLongUrls;
 
+    /**
+     * @param $hasRedirectRules - It's `null` for Shlink older than 4.3
+     */
     private function __construct(
         public string $shortCode,
         public string $shortUrl,
@@ -24,6 +27,7 @@ final readonly class ShortUrl
         public string|null $title,
         public bool $crawlable,
         public bool $forwardQuery,
+        public bool|null $hasRedirectRules,
         public array $tags,
         public ShortUrlMeta $meta,
         public VisitsSummary $visitsSummary,
@@ -48,6 +52,7 @@ final readonly class ShortUrl
             title: $payload['title'] ?? null,
             crawlable: $payload['crawlable'] ?? false,
             forwardQuery: $payload['forwardQuery'] ?? false,
+            hasRedirectRules: $payload['hasRedirectRules'] ?? null,
             tags: $payload['tags'] ?? [],
             meta: ShortUrlMeta::fromArray($payload['meta'] ?? []),
             visitsSummary: VisitsSummary::fromArrayWithFallback($payload['visitsSummary'] ?? [], $visitsCount),

--- a/src/ShortUrls/Model/ShortUrlsFilter.php
+++ b/src/ShortUrls/Model/ShortUrlsFilter.php
@@ -65,6 +65,11 @@ final class ShortUrlsFilter implements ArraySerializable
         return $this->cloneWithProp('orderBy', sprintf('%s-DESC', $field->value));
     }
 
+    public function forDomain(string $domain): self
+    {
+        return $this->cloneWithProp('domain', $domain);
+    }
+
     private function cloneWithProp(string $prop, mixed $value): self
     {
         $clone = new self($this->query);

--- a/src/Visits/Model/OrphanVisit.php
+++ b/src/Visits/Model/OrphanVisit.php
@@ -8,7 +8,7 @@ use DateTimeInterface;
 
 final readonly class OrphanVisit implements VisitInterface
 {
-    private function __construct(private Visit $visit, private string $visitedUrl, private OrphanVisitType $type)
+    private function __construct(private Visit $visit, private OrphanVisitType $type)
     {
     }
 
@@ -16,7 +16,6 @@ final readonly class OrphanVisit implements VisitInterface
     {
         return new self(
             visit: Visit::fromArray($payload),
-            visitedUrl: $payload['visitedUrl'] ?? '',
             type: OrphanVisitType::tryFrom($payload['type'] ?? '') ?? OrphanVisitType::REGULAR_NOT_FOUND,
         );
     }
@@ -48,7 +47,12 @@ final readonly class OrphanVisit implements VisitInterface
 
     public function visitedUrl(): string
     {
-        return $this->visitedUrl;
+        return $this->visit->visitedUrl();
+    }
+
+    public function redirectUrl(): string|null
+    {
+        return $this->visit->redirectUrl();
     }
 
     public function type(): OrphanVisitType

--- a/src/Visits/Model/Visit.php
+++ b/src/Visits/Model/Visit.php
@@ -14,6 +14,8 @@ final readonly class Visit implements VisitInterface
         private DateTimeInterface $date,
         private string $userAgent,
         private bool $potentialBot,
+        private string $visitedUrl,
+        private string|null $redirectUrl,
         private VisitLocation|null $location,
     ) {
     }
@@ -26,6 +28,8 @@ final readonly class Visit implements VisitInterface
             date: DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $payload['date']),
             userAgent: $payload['userAgent'] ?? '',
             potentialBot: $payload['potentialBot'] ?? false,
+            visitedUrl: $payload['visitedUrl'] ?? '',
+            redirectUrl: $payload['redirectUrl'] ?? null,
             location: isset($payload['visitLocation']) ? VisitLocation::fromArray($payload['visitLocation']) : null,
         );
     }
@@ -53,5 +57,15 @@ final readonly class Visit implements VisitInterface
     public function location(): VisitLocation|null
     {
         return $this->location;
+    }
+
+    public function visitedUrl(): string
+    {
+        return $this->visitedUrl;
+    }
+
+    public function redirectUrl(): string|null
+    {
+        return $this->redirectUrl;
     }
 }

--- a/src/Visits/Model/VisitInterface.php
+++ b/src/Visits/Model/VisitInterface.php
@@ -13,4 +13,6 @@ interface VisitInterface
     public function userAgent(): string;
     public function potentialBot(): bool;
     public function location(): VisitLocation|null;
+    public function visitedUrl(): string;
+    public function redirectUrl(): string|null;
 }

--- a/test/RedirectRules/Model/RedirectConditionTest.php
+++ b/test/RedirectRules/Model/RedirectConditionTest.php
@@ -85,4 +85,24 @@ class RedirectConditionTest extends TestCase
         self::assertEquals('192.168.1.100', $condition->matchValue);
         self::assertNull($condition->matchKey);
     }
+
+    #[Test]
+    public function forGeolocationCountryCodeCreatesExpectedCondition(): void
+    {
+        $condition = RedirectCondition::forGeolocationCountryCode('US');
+
+        self::assertEquals(RedirectConditionType::GEOLOCATION_COUNTRY_CODE, $condition->type);
+        self::assertEquals('US', $condition->matchValue);
+        self::assertNull($condition->matchKey);
+    }
+
+    #[Test]
+    public function forGeolocationCityNameCreatesExpectedCondition(): void
+    {
+        $condition = RedirectCondition::forGeolocationCityName('Los Angeles');
+
+        self::assertEquals(RedirectConditionType::GEOLOCATION_CITY_NAME, $condition->type);
+        self::assertEquals('Los Angeles', $condition->matchValue);
+        self::assertNull($condition->matchKey);
+    }
 }

--- a/test/ShortUrls/Model/ShortUrlsFilterTest.php
+++ b/test/ShortUrls/Model/ShortUrlsFilterTest.php
@@ -56,5 +56,6 @@ class ShortUrlsFilterTest extends TestCase
             fn () => ShortUrlsFilter::create()->excludingMaxVisitsReached()->excludingPastValidUntil(),
             ['excludeMaxVisitsReached' => 'true', 'excludePastValidUntil' => 'true'],
         ];
+        yield [fn () => ShortUrlsFilter::create()->forDomain('s.test'), ['domain' => 's.test']];
     }
 }


### PR DESCRIPTION
Add support for new features introduced in Shlink 4.3

Additionally, expose the `visitedUrl` for non-orphan visits, which was introduced in Shlink 4.1.0