### PR TITLE
Add support for Shlink 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.4', '8.5']
-        shlink-version: ['4.6', '4.5', '4.4', '4.3', '4.2', '4.1', '4.0']
+        shlink-version: ['5.0', '4.6', '4.5', '4.4', '4.3', '4.2', '4.1', '4.0']
         shlink-api-version: ['3']
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [3.1.0] - 2026-01-11
 ### Added
-* *Nothing*
+* Add support for `before-date` and `after-date` redirect conditions, introduced in Shlink 5.0.0
 
 ### Changed
 * *Nothing*

--- a/src/RedirectRules/Model/RedirectCondition.php
+++ b/src/RedirectRules/Model/RedirectCondition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\SDK\RedirectRules\Model;
 
+use DateTimeInterface;
 use JsonSerializable;
 use Shlinkio\Shlink\SDK\ShortUrls\Model\Device;
 
@@ -59,6 +60,16 @@ final readonly class RedirectCondition implements JsonSerializable
     public static function forGeolocationCityName(string $cityName): self
     {
         return new self(RedirectConditionType::GEOLOCATION_CITY_NAME, $cityName);
+    }
+
+    public static function forBeforeDate(DateTimeInterface $date): self
+    {
+        return new self(RedirectConditionType::BEFORE_DATE, $date->format(DateTimeInterface::ATOM));
+    }
+
+    public static function forAfterDate(DateTimeInterface $date): self
+    {
+        return new self(RedirectConditionType::AFTER_DATE, $date->format(DateTimeInterface::ATOM));
     }
 
     public static function fromArray(array $payload): self

--- a/src/RedirectRules/Model/RedirectConditionType.php
+++ b/src/RedirectRules/Model/RedirectConditionType.php
@@ -12,5 +12,7 @@ enum RedirectConditionType: string
     case IP_ADDRESS = 'ip-address';
     case GEOLOCATION_COUNTRY_CODE = 'geolocation-country-code';
     case GEOLOCATION_CITY_NAME = 'geolocation-city-name';
+    case BEFORE_DATE = 'before-date';
+    case AFTER_DATE = 'after-date';
     case UNKNOWN = 'unknown';
 }

--- a/test/RedirectRules/Model/RedirectConditionTest.php
+++ b/test/RedirectRules/Model/RedirectConditionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ShlinkioTest\Shlink\SDK\RedirectRules\Model;
 
+use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -123,6 +124,28 @@ class RedirectConditionTest extends TestCase
 
         self::assertEquals(RedirectConditionType::GEOLOCATION_CITY_NAME, $condition->type);
         self::assertEquals('Los Angeles', $condition->matchValue);
+        self::assertNull($condition->matchKey);
+    }
+
+    #[Test]
+    public function forBeforeDateCreatesExpectedCondition(): void
+    {
+        $date = new DateTimeImmutable('2026-01-01');
+        $condition = RedirectCondition::forBeforeDate($date);
+
+        self::assertEquals(RedirectConditionType::BEFORE_DATE, $condition->type);
+        self::assertEquals($date->format(DateTimeImmutable::ATOM), $condition->matchValue);
+        self::assertNull($condition->matchKey);
+    }
+
+    #[Test]
+    public function forAfterDateCreatesExpectedCondition(): void
+    {
+        $date = new DateTimeImmutable('2026-01-01');
+        $condition = RedirectCondition::forAfterDate($date);
+
+        self::assertEquals(RedirectConditionType::AFTER_DATE, $condition->type);
+        self::assertEquals($date->format(DateTimeImmutable::ATOM), $condition->matchValue);
         self::assertNull($condition->matchKey);
     }
 }


### PR DESCRIPTION
Add support for `before-date` and `after-date` redirect conditions, introduced in Shlink 5.0.0.

Additionally, include Shlink 5.0 to the integration tests matrix.